### PR TITLE
Fix Canary Parser

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -64,8 +64,8 @@ const parseCurrentCanaryStep = (
 ): { currentStep: any; currentStepIndex: number } => {
   const { status, spec } = resource;
   const canary = spec.strategy?.canary;
-  if (!canary || canary.steps.length === 0) {
-    return null;
+  if (!canary || !canary.steps || canary.steps.length === 0) {
+    return { currentStep: null, currentStepIndex: -1 };
   }
   let currentStepIndex = 0;
   if (status.currentStepIndex) {


### PR DESCRIPTION
Rollouts Extension fails when Canary steps are not defined or when steps is an empty list:

`steps` is null example
```yaml
spec:
  strategy:
    canary:
      maxSurge: 1
      maxUnavailable: 1
```

`steps` is an empty list example:
```yaml
spec:
  strategy:
    canary:
      maxSurge: 1
      maxUnavailable: 1
      steps: []
```

Tested with https://github.com/argoproj/argo-rollouts/blob/master/examples/rollout-rolling-update.yaml

Closes #2