### PR TITLE
Parse workloadRef from tree so we can populate containers

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -202,11 +202,11 @@ const parseReplicaSets = (tree: any, rollout: any): RolloutReplicaSetInfo[] => {
   });
 };
 
-const parseWorkloadRef = (tree: any, rollout: any): State =>
+const parseWorkloadRef = (tree: any, rollout: any): State | undefined =>
   (tree.nodes.find(
     (node) =>
       node.kind === "Deployment" && node.name === rollout.spec.workloadRef.name
-  ) as State) || {};
+  ) as State);
 
 interface ApplicationResourceTree {}
 export const Extension = (props: {

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -54,6 +54,13 @@ const parseInfoFromResourceNode = (
     for (const c of spec.template?.spec?.containers) {
       ro.containers.push({ name: c.name, image: c.image });
     }
+  } else if (spec.workloadRef) {
+    const deployment = parseWorkloadRef(tree, resource);
+    if (deployment && deployment.spec) {
+      for (const c of deployment.spec.template?.spec?.containers) {
+        ro.containers.push({ name: c.name, image: c.image });
+      }
+    }
   }
 
   ro.current = status.replicas;
@@ -194,6 +201,12 @@ const parseReplicaSets = (tree: any, rollout: any): RolloutReplicaSetInfo[] => {
     return rs;
   });
 };
+
+const parseWorkloadRef = (tree: any, rollout: any): State =>
+  (tree.nodes.find(
+    (node) =>
+      node.kind === "Deployment" && node.name === rollout.spec.workloadRef.name
+  ) as State) || {};
 
 interface ApplicationResourceTree {}
 export const Extension = (props: {


### PR DESCRIPTION
This way, the container view is not empty (when using workloadRef).

Continuation of: https://github.com/argoproj-labs/rollout-extension/pull/18

LE: this doesn't work, as the ApplicationTree stores only metadata, not the Deployment spec. Fetching it would be an additional backend call (https://github.com/argoproj/argo-cd/blob/master/ui/src/app/shared/services/applications-service.ts#L275). However, for this call we need to know the "applicationNamespace" which is also not exposed to the extension.