### PR TITLE
fix: `currentStepIndex: 0` is a valid step

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -23,7 +23,7 @@ const parseInfoFromResourceNode = (
     const steps = spec.strategy?.canary?.steps || [];
     ro.steps = steps;
 
-    if (steps && status.currentStepIndex && steps.length > 0) {
+    if (steps && status.currentStepIndex !== null && steps.length > 0) {
       ro.step = `${status.currentStepIndex}/${steps.length}`;
     }
 


### PR DESCRIPTION
before this change, the extension would not display the `0/N` state, as 0 is falsey.

Signed-off-by: Alex Eftimie <alex.eftimie@getyourguide.com>