### PR TITLE
fix: make copies of ReplicaSets / Pods to avoid clash with grouped code

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -160,14 +160,16 @@ const parseReplicaSets = (tree: any, rollout: any): RolloutReplicaSetInfo[] => {
         parentRef?.kind === "Rollout" &&
         parentRef?.name === rollout?.metadata?.name
       ) {
-        rs.pods = [];
-        rs.objectMeta = {
-          name: rs.name,
-          uid: rs.uid,
-        };
-        rs.status = rs.health.status,
-        rs.revision = parseRevision(rs);
-        ownedReplicaSets[rs?.name] = rs;
+        let ownedRS = {
+          pods: [],
+          objectMeta: {
+            name: rs.name,
+            uid: rs.uid,
+          },
+          status: rs.health.status,
+          revision: parseRevision(rs),
+        }
+        ownedReplicaSets[rs?.name] = ownedRS;
       }
     }
   }
@@ -175,15 +177,17 @@ const parseReplicaSets = (tree: any, rollout: any): RolloutReplicaSetInfo[] => {
   const podMap: { [key: string]: any[] } = {};
 
   for (const pod of allPods) {
-    pod.objectMeta = {
-      name: pod.name,
-      uid: pod.uid,
-    };
-    pod.status = parsePodStatus(pod);
+    let ownedPod = {
+      objectMeta: {
+        name: pod.name,
+        uid: pod.uid,
+      },
+      status: parsePodStatus(pod),
+    }
     for (const parentRef of pod.parentRefs) {
       const pods = podMap[parentRef?.name] || [];
       if (parentRef.kind === "ReplicaSet" && pods?.length > -1) {
-        pods.push(pod);
+        pods.push(ownedPod);
         podMap[parentRef?.name] = [...pods];
       }
     }


### PR DESCRIPTION
fixes: #10 

Signed-off-by: Alex Eftimie <alex.eftimie@getyourguide.com>

I noticed that wherever I'm in a grouped view (for instance Node view) and open the extension, the main website gets poluted with invalid pods (no metadata, just objectMeta) which results inevitably in a crash like this:

<img width="1035" alt="Screenshot 2023-01-16 at 23 25 41" src="https://user-images.githubusercontent.com/346576/212775058-665115ec-76ae-41aa-98b2-15204d92ef6f.png">


With this change, I'm using copies of the RS and Pod objects so that they are not tainted in CD.