### PR TITLE
Update installer with the latest version

### DIFF
--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   sources:
   - web:
-      url: https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.1/extension.tar
+      url: https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.3/extension.tar


### PR DESCRIPTION
https://github.com/argoproj-labs/rollout-extension/releases/tag/v0.3.3
The installer was not updated with the new release of v0.3.3