### PR TITLE
chore: use latest version in manifest

### DIFF
--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   sources:
   - web:
-      url: https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.3/extension.tar
+      url: https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.4/extension.tar


### PR DESCRIPTION
use v0.3.4

https://github.com/argoproj-labs/rollout-extension/releases