### PR TITLE
fix(ui): fix display of analysis on JSON parsing error

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "argo-rollouts": "git+https://github.com/argoproj/argo-rollouts.git#b0d74e5def390e8d7f33fb98c7450519037d30be",
+    "argo-rollouts": "git+https://github.com/argoproj/argo-rollouts.git#a4d50d8e65d5fa33a6e7f33f43be9a3df83b06f7",
     "argo-ui": "git+https://github.com/argoproj/argo-ui.git#5ff344ac9692c14dd108468bd3c020c3c75181cb",
     "classnames": "2.2.6",
     "json-loader": "^0.5.7",


### PR DESCRIPTION
When a JSON contained unexpected values like N or NaN, the analysis display failed, showing the message: 'Something went wrong with Extension for Rollout' along with the error.

```javascript
ncaught SyntaxError: Unexpected token 'N', "[NaN]" is not valid JSON
    at JSON.parse (<anonymous>)
    at a (transforms.ts:620:30)
    at n.length.n.reduce.chartable (transforms.ts:472:38)
    at Array.reduce (<anonymous>)
    at t.transformMeasurements (transforms.ts:467:25)
    at transforms.ts:241:48
    at Array.forEach (<anonymous>)
```

This update resolves the issue by addressing the problem described in this PR: https://github.com/argoproj/argo-rollouts/pull/3801