### PR TITLE
Fix: Improper null check order (CWE-476)

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -19,9 +19,9 @@ const parseInfoFromResourceNode = (app: any, tree: any, resource: State) => {
 
     ro.replicaSets = parseReplicaSets(tree, resource);
 
-    if (spec.strategy.canary) {
+    if (spec.strategy?.canary) {
         ro.strategy = 'Canary';
-        const steps = spec.strategy?.canary?.steps || [];
+        const steps = spec.strategy.canary.steps || [];
         ro.steps = steps;
 
         if (steps && status.currentStepIndex !== null && steps.length > 0) {
@@ -286,8 +286,8 @@ const parseReplicaSets = (tree: any, rollout: any): RolloutReplicaSetInfo[] => {
                         pods.push(ownedPod);
                     }
                 }
-                
-                ownedReplicaSets[rs?.name] = {
+
+                ownedReplicaSets[rs.name] = {
                     objectMeta: {
                         name: rs.name,
                         uid: rs.uid,


### PR DESCRIPTION
This PR is to fix a REVERSE_INULL ([CWE-476](https://cwe.mitre.org/data/definitions/476.html)) by ensuring consistent null checks—either placing the null check before any dereference, or avoiding null checks that imply the value may be null when it has already been dereferenced along all paths leading to the check.
