### PR TITLE
fix: externalize react-dom and react/jsx-runtime for React 19 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ The project introduces the Argo Rollout dashboard into the Argo CD Web UI.
 
 ![image](https://user-images.githubusercontent.com/426437/136460261-00d3dc31-ad20-4044-a7be-091803b8678f.png)
 
+## Compatibility
+
+Starting with `v0.4.0`, this extension requires **Argo CD v3.5 or later**. For Argo CD versions earlier than v3.5, use extension version `v0.3.x`.
+
+| Rollout Extension | Argo CD       |
+| ----------------- | ------------- |
+| `v0.4.0`+         | `v3.5`+       |
+| `v0.3.x`          | `< v3.5`      |
+
 ## Install UI extension
 
 To install the extension use the [argocd-extension-installer](https://github.com/argoproj-labs/argocd-extension-installer) init container which runs during the startup of the argocd server.

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -17,6 +17,8 @@ const config = {
   },
   externals: {
     react: 'React',
+    'react-dom': 'ReactDOM',
+    'react/jsx-runtime': 'ReactJSXRuntime',
   },
   module: {
     rules: [


### PR DESCRIPTION
## Problem

When ArgoCD is upgraded to use React 19, this extension fails to load with:

    TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')

The extension externalizes `react` (using `window.React`) but bundles its own
copy of `react-dom`. React DOM 18, when bundled, internally reads:

    React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner

In React 19, `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` was renamed
and its shape changed entirely — `ReactCurrentOwner` no longer exists on it —
causing the crash.

## Fix

Externalize `react-dom` and `react/jsx-runtime` alongside `react`. ArgoCD core
already exposes `window.ReactDOM` and `window.ReactJSXRuntime` as globals, so
the extension will use the single React 19 instance from the host app instead of
bundling a conflicting React 18 copy.

## Changes

- `ui/webpack.config.js`: add `'react-dom': 'ReactDOM'` and
  `'react/jsx-runtime': 'ReactJSXRuntime'` to `externals`